### PR TITLE
Add category selection and animations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,9 +21,16 @@ const placeholderData = {
   }
 };
 
+const categories = {
+  streetFood: { label: 'Street Food', title: 'Top 3 Street Food' },
+  restaurants: { label: 'Restaurants', title: 'Top 3 Famous Restaurants' },
+  attractions: { label: 'Attractions', title: 'Top 3 Places to Visit' }
+};
+
 function App() {
   const [query, setQuery] = useState('Cetinje');
   const [cityData, setCityData] = useState(null);
+  const [category, setCategory] = useState('streetFood');
 
   useEffect(() => {
     // In a real app, fetch from API: /api/cities?name=<query>
@@ -36,10 +43,10 @@ function App() {
   }, [query]);
 
   return (
-    <div className="min-h-screen bg-gray-100 p-8">
-      <header className="text-center mb-8">
+    <div className="min-h-screen bg-gray-100 flex flex-col items-center justify-center p-8">
+      <header className="text-center mb-8 w-full flex flex-col items-center">
         <h1 className="text-4xl font-bold mb-4">Choose Local Over Tourist Traps</h1>
-        <div className="relative mx-auto w-full max-w-xl">
+        <div className="relative mx-auto w-full max-w-xl mb-4">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -62,15 +69,24 @@ function App() {
             className="w-full px-4 py-3 pl-10 border-2 border-gray-300 rounded-full shadow focus:border-blue-500 focus:ring-2 focus:ring-blue-200 focus:outline-none transition-all duration-300"
           />
         </div>
+        <div className="w-full max-w-xs">
+          <select
+            value={category}
+            onChange={e => setCategory(e.target.value)}
+            className="w-full px-4 py-2 border-2 border-gray-300 rounded-full shadow focus:border-blue-500 focus:ring-2 focus:ring-blue-200 focus:outline-none transition-all duration-300"
+          >
+            {Object.entries(categories).map(([key, { label }]) => (
+              <option key={key} value={key}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
       </header>
 
-      <main className="max-w-4xl mx-auto">
+      <main className="max-w-4xl mx-auto w-full">
         {cityData ? (
-          <>
-            <CategorySection title="Top 3 Street Food" items={cityData.streetFood} />
-            <CategorySection title="Top 3 Famous Restaurants" items={cityData.restaurants} />
-            <CategorySection title="Top 3 Places to Visit" items={cityData.attractions} />
-          </>
+          <CategorySection title={categories[category].title} items={cityData[category]} />
         ) : (
           <p className="text-center text-gray-500">No data found for "{query}".</p>
         )}
@@ -85,7 +101,10 @@ function CategorySection({ title, items }) {
       <h2 className="text-2xl font-semibold mb-4">{title}</h2>
       <ul className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {items.map(item => (
-          <li key={item.name} className="bg-white p-4 rounded shadow">
+          <li
+            key={item.name}
+            className="bg-white p-4 rounded shadow transition transform duration-300 hover:scale-105 hover:shadow-lg animate-fadeIn"
+          >
             <h3 className="font-bold text-lg">{item.name}</h3>
             <p className="text-sm text-gray-600 mt-1">{item.description}</p>
           </li>

--- a/src/index.css
+++ b/src/index.css
@@ -6,3 +6,18 @@ html, body, #root {
   height: 100%;
   margin: 0;
 }
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fadeIn {
+  animation: fadeIn 0.5s ease-out both;
+}


### PR DESCRIPTION
## Summary
- center search input
- add dropdown for selecting a category
- show results only for the chosen category
- add fade-in effect on results

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844582085c483298cb16c272ed5526c